### PR TITLE
Fix Description Parameter

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -12,13 +12,13 @@ type Atom struct {
 }
 
 type AtomEntry struct {
-	Title     CDATA       `xml:"title"`
-	Links     []AtomLink  `xml:"link"`
-	Author    string      `xml:"author>name"`
-	Content   AtomContent `xml:"content"`
-	Updated   string      `xml:"updated"`
-	Published string      `xml:"published"`
-	ID        string      `xml:"id"`
+	Title     CDATA        `xml:"title"`
+	Links     []AtomLink   `xml:"link"`
+	Author    string       `xml:"author>name"`
+	Content   *AtomContent `xml:"content,omitempty"`
+	Updated   string       `xml:"updated"`
+	Published string       `xml:"published"`
+	ID        string       `xml:"id"`
 }
 
 type AtomContent struct {
@@ -39,7 +39,7 @@ func NewAtom(results *AlgoliaSearchResponse, op *OutputParams) *Atom {
 		Title:   op.Title,
 		Updated: Timestamp("atom", UTCNow()),
 		Links: []AtomLink{
-			AtomLink{op.SelfLink, "self", "application/atom+xml"},
+			{op.SelfLink, "self", "application/atom+xml"},
 		},
 	}
 
@@ -50,11 +50,15 @@ func NewAtom(results *AlgoliaSearchResponse, op *OutputParams) *Atom {
 			Updated:   Timestamp("atom", hit.GetCreatedAt()),
 			Published: Timestamp("atom", hit.GetCreatedAt()),
 			Links: []AtomLink{
-				AtomLink{hit.GetURL(op.LinkTo), "alternate", ""},
+				{hit.GetURL(op.LinkTo), "alternate", ""},
 			},
-			Author:  hit.Author,
-			Content: AtomContent{"html", hit.GetDescription()},
+			Author: hit.Author,
 		}
+
+		if op.Description != descriptionDisabledFlag {
+			entry.Content = &AtomContent{"html", hit.GetDescription()}
+		}
+
 		atom.Entries = append(atom.Entries, entry)
 	}
 

--- a/jsonfeed.go
+++ b/jsonfeed.go
@@ -12,7 +12,7 @@ type JSONFeed struct {
 type JSONFeedItem struct {
 	ID          string `json:"id"`
 	Title       string `json:"title"`
-	ContentHTML string `json:"content_html"`
+	ContentHTML string `json:"content_html,omitempty"`
 	URL         string `json:"url"`
 	ExternalURL string `json:"external_url"`
 	Published   string `json:"date_published"`
@@ -30,12 +30,16 @@ func NewJSONFeed(results *AlgoliaSearchResponse, op *OutputParams) *JSONFeed {
 		item := JSONFeedItem{
 			ID:          hit.GetPermalink(),
 			Title:       hit.GetTitle(),
-			ContentHTML: hit.GetDescription(),
 			URL:         hit.GetURL(op.LinkTo),
 			ExternalURL: hit.GetPermalink(),
 			Published:   Timestamp("jsonfeed", hit.GetCreatedAt()),
 			Author:      hit.Author,
 		}
+
+		if op.Description != descriptionDisabledFlag {
+			item.ContentHTML = hit.GetDescription()
+		}
+
 		j.Items = append(j.Items, item)
 	}
 	return &j

--- a/rss.go
+++ b/rss.go
@@ -1,5 +1,7 @@
 package main
 
+const descriptionDisabledFlag = "0"
+
 // http://cyber.harvard.edu/rss/rss.html
 type RSS struct {
 	XMLName       string    `xml:"rss"`
@@ -23,7 +25,7 @@ type RSSPermalink struct {
 
 type RSSItem struct {
 	Title       CDATA        `xml:"title"`
-	Description CDATA        `xml:"description"`
+	Description *CDATA       `xml:"description,omitempty"`
 	Published   string       `xml:"pubDate"`
 	Link        string       `xml:"link"`
 	Author      string       `xml:"dc:creator"`
@@ -47,14 +49,18 @@ func NewRSS(results *AlgoliaSearchResponse, op *OutputParams) *RSS {
 
 	for _, hit := range results.Hits {
 		item := RSSItem{
-			Title:       CDATA{hit.GetTitle()},
-			Link:        hit.GetURL(op.LinkTo),
-			Description: CDATA{hit.GetDescription()},
-			Author:      hit.Author,
-			Comments:    hit.GetPermalink(),
-			Published:   Timestamp("rss", hit.GetCreatedAt()),
-			Permalink:   RSSPermalink{hit.GetPermalink(), "false"},
+			Title:     CDATA{hit.GetTitle()},
+			Link:      hit.GetURL(op.LinkTo),
+			Author:    hit.Author,
+			Comments:  hit.GetPermalink(),
+			Published: Timestamp("rss", hit.GetCreatedAt()),
+			Permalink: RSSPermalink{hit.GetPermalink(), "false"},
 		}
+
+		if op.Description != descriptionDisabledFlag {
+			item.Description = &CDATA{hit.GetDescription()}
+		}
+
 		rss.Items = append(rss.Items, item)
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/gin-gonic/gin"
 )
 
 const (
@@ -60,6 +61,7 @@ func ParseRequest(c *gin.Context, sp *SearchParams, op *OutputParams) {
 		c.String(http.StatusBadRequest, err.Error())
 		return
 	}
+
 	op.Format = c.GetString("format")
 	op.SelfLink = SiteURL + c.Request.URL.String()
 }


### PR DESCRIPTION
## Problem

See #49.

The [hnrss.github.io/#description-parameter](https://hnrss.github.io/#description-parameter) is documented but is not currently implemented.

## Solution

When generating items within any of the feed types (Atom, JSON, RSS), check if `OutputParams.Description` has been set to `0`.

If so then do not assign the HTML description content to the item.

Note that `omitempty` struct tags have been added to each of the item types to ensure that empty description blocks are not included when the flag is enabled. 