### PR TITLE
Description Flag Unit Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+on: push
+permissions:
+  contents: read
+jobs:
+  test:
+    name: Run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Test
+        run: go test -race -cover ./...

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-hnrss — Hacker News RSS
-========================
+# hnrss — Hacker News RSS
+
+[![GoDoc](https://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](https://pkg.go.dev/github.com/hnrss/hnrss)
+[![Builds](https://img.shields.io/github/checks-status/hnrss/hnrss/main?label=build&style=flat-square)](https://github.com/hnrss/hnrss/actions?query=branch%master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/hnrss/hnrss?style=flat-square)](https://goreportcard.com/report/github.com/hnrss/hnrss)
 
 hnrss provides custom, realtime RSS feeds for Hacker News.
 
 The [project page](http://hnrss.org/) explains all available RSS feeds.
 
-Overview
---------
+## Overview
 
 The following feeds are available:
 
@@ -20,15 +22,14 @@ The following feeds are available:
 - **Users** -- New [posts](https://hnrss.org/submitted?id=tokenadult) and [comments](https://hnrss.org/threads?id=tptacek) made by a given user.
 - **Threads** -- Each new comment made [in a given thread](https://hnrss.org/item?id=7864813).
 
-[Hacker News]: https://news.ycombinator.com/
-[Ask HN]: https://hnrss.org/ask
-[Show HN]: https://hnrss.org/show
+[hacker news]: https://news.ycombinator.com/
+[ask hn]: https://hnrss.org/ask
+[show hn]: https://hnrss.org/show
 [polls]: https://hnrss.org/polls
 [jobs]: https://hnrss.org/jobs
 [whoishiring]: https://hnrss.org/whoishiring/jobs
 
-Support
--------
+## Support
 
 While running hnrss is by no means “breaking the bank,” every little
 bit helps for when the monthly hosting bill or domain registration
@@ -38,8 +39,7 @@ much appreciated. Thanks!
 
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=ZP9Q7QUNS3QYY)
 
-Credits
--------
+## Credits
 
 hnrss is powered by [Algolia](https://hn.algolia.com/api), the
 [official Hacker News API provider](https://news.ycombinator.com/item?id=7547578).

--- a/algolia.go
+++ b/algolia.go
@@ -57,9 +57,9 @@ func (hit AlgoliaSearchHit) isSelfPost() bool {
 func (hit AlgoliaSearchHit) GetTitle() string {
 	if hit.isComment() {
 		return fmt.Sprintf("New comment by %s in \"%s\"", hit.Author, html.UnescapeString(hit.StoryTitle))
-	} else {
-		return html.UnescapeString(hit.Title)
 	}
+
+	return html.UnescapeString(hit.Title)
 }
 
 func (hit AlgoliaSearchHit) GetPermalink() string {
@@ -85,7 +85,7 @@ func buildTemplateEngine(name string) *template.Template {
 	return t.Funcs(fm)
 }
 
-func (hit AlgoliaSearchHit) GetDescription() string {
+func (hit AlgoliaSearchHit) GetDescription() (string, error) {
 	var (
 		b bytes.Buffer
 		t = buildTemplateEngine("default")
@@ -112,8 +112,11 @@ func (hit AlgoliaSearchHit) GetDescription() string {
 `))
 	}
 
-	t.Execute(&b, hit)
-	return b.String()
+	if err := t.Execute(&b, hit); err != nil {
+		return "", fmt.Errorf("failed to generate description template: %w", err)
+	}
+
+	return b.String(), nil
 }
 
 func (hit AlgoliaSearchHit) GetCreatedAt() time.Time {

--- a/atom.go
+++ b/atom.go
@@ -32,7 +32,7 @@ type AtomLink struct {
 	Type         string `xml:"type,attr,omitempty"`
 }
 
-func NewAtom(results *AlgoliaSearchResponse, op *OutputParams) *Atom {
+func NewAtom(results *AlgoliaSearchResponse, op *OutputParams) (*Atom, error) {
 	atom := Atom{
 		NS:      NSAtom,
 		ID:      op.SelfLink,
@@ -56,11 +56,19 @@ func NewAtom(results *AlgoliaSearchResponse, op *OutputParams) *Atom {
 		}
 
 		if op.Description != descriptionDisabledFlag {
-			entry.Content = &AtomContent{"html", hit.GetDescription()}
+			desc, err := hit.GetDescription()
+			if err != nil {
+				return nil, err
+			}
+
+			entry.Content = &AtomContent{
+				Type:  "html",
+				Value: desc,
+			}
 		}
 
 		atom.Entries = append(atom.Entries, entry)
 	}
 
-	return &atom
+	return &atom, nil
 }

--- a/bestcomments.go
+++ b/bestcomments.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"astuart.co/goq"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"astuart.co/goq"
+	"github.com/gin-gonic/gin"
 )
 
 func BestComments(c *gin.Context) {
@@ -37,7 +38,7 @@ func BestComments(c *gin.Context) {
 	sp.Filters = strings.Join(oids, " OR ")
 	sp.Count = strconv.Itoa(len(oids))
 
-	op.Title = fmt.Sprintf("Hacker News: Best Comments")
+	op.Title = "Hacker News: Best Comments"
 	op.Link = "https://news.ycombinator.com/bestcomments"
 
 	Generate(c, &sp, &op)

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	astuart.co/goq v1.0.0
 	github.com/gin-contrib/gzip v0.0.3
 	github.com/gin-gonic/gin v1.7.1
+	github.com/stretchr/testify v1.4.0
 )

--- a/handlers.go
+++ b/handlers.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 func Newest(c *gin.Context) {
@@ -221,7 +222,7 @@ func Item(c *gin.Context) {
 	ParseRequest(c, &sp, &op)
 
 	sp.Tags = "comment,story_" + sp.ID
-	if (sp.Author != "") {
+	if sp.Author != "" {
 		sp.Tags = fmt.Sprintf("%s,author_%s", sp.Tags, sp.Author)
 	}
 	sp.SearchAttributes = "default"

--- a/jsonfeed.go
+++ b/jsonfeed.go
@@ -19,7 +19,7 @@ type JSONFeedItem struct {
 	Author      string `json:"author"`
 }
 
-func NewJSONFeed(results *AlgoliaSearchResponse, op *OutputParams) *JSONFeed {
+func NewJSONFeed(results *AlgoliaSearchResponse, op *OutputParams) (*JSONFeed, error) {
 	j := JSONFeed{
 		Version:     "https://jsonfeed.org/version/1",
 		Title:       op.Title,
@@ -37,10 +37,16 @@ func NewJSONFeed(results *AlgoliaSearchResponse, op *OutputParams) *JSONFeed {
 		}
 
 		if op.Description != descriptionDisabledFlag {
-			item.ContentHTML = hit.GetDescription()
+			desc, err := hit.GetDescription()
+			if err != nil {
+				return nil, err
+			}
+
+			item.ContentHTML = desc
 		}
 
 		j.Items = append(j.Items, item)
 	}
-	return &j
+
+	return &j, nil
 }

--- a/rss.go
+++ b/rss.go
@@ -33,7 +33,7 @@ type RSSItem struct {
 	Permalink   RSSPermalink `xml:"guid"`
 }
 
-func NewRSS(results *AlgoliaSearchResponse, op *OutputParams) *RSS {
+func NewRSS(results *AlgoliaSearchResponse, op *OutputParams) (*RSS, error) {
 	rss := RSS{
 		Version:       "2.0",
 		NSAtom:        NSAtom,
@@ -58,11 +58,18 @@ func NewRSS(results *AlgoliaSearchResponse, op *OutputParams) *RSS {
 		}
 
 		if op.Description != descriptionDisabledFlag {
-			item.Description = &CDATA{hit.GetDescription()}
+			desc, err := hit.GetDescription()
+			if err != nil {
+				return nil, err
+			}
+
+			item.Description = &CDATA{
+				Value: desc,
+			}
 		}
 
 		rss.Items = append(rss.Items, item)
 	}
 
-	return &rss
+	return &rss, nil
 }

--- a/rss_test.go
+++ b/rss_test.go
@@ -1,0 +1,78 @@
+package main_test
+
+import (
+	"testing"
+
+	hnrss "github.com/hnrss/hnrss"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRSSOutputParamsDescription(t *testing.T) {
+	t.Parallel()
+
+	results := &hnrss.AlgoliaSearchResponse{
+		Hits: []hnrss.AlgoliaSearchHit{
+			{
+				Tags:      []string{"story", "author_dragonsh", "story_29367715"},
+				ObjectID:  "29367715",
+				Title:     "Mercurial Release 6.0",
+				URL:       "https://www.mercurial-scm.org/wiki/Release6.0",
+				Author:    "dragonsh",
+				CreatedAt: "2021-11-28T10:11:15.000Z",
+				Points:    1,
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		outputParamsFunc func(*hnrss.OutputParams)
+		want             require.ValueAssertionFunc
+	}{
+		"Blank": {
+			want: require.NotNil,
+		},
+		"Enabled": {
+			outputParamsFunc: func(op *hnrss.OutputParams) {
+				op.Description = "1"
+			},
+			want: require.NotNil,
+		},
+		"Disabled": {
+			outputParamsFunc: func(op *hnrss.OutputParams) {
+				op.Description = "0"
+			},
+			want: require.Nil,
+		},
+		"RandomValue": {
+			outputParamsFunc: func(op *hnrss.OutputParams) {
+				op.Description = "foo"
+			},
+			want: require.NotNil,
+		},
+	}
+
+	for n, testCase := range tests {
+		tc := testCase
+
+		t.Run(n, func(t *testing.T) {
+			t.Parallel()
+
+			outputParams := &hnrss.OutputParams{
+				Title:    "Hacker News: Newest",
+				Link:     "https://news.ycombinator.com/newest",
+				Format:   "rss",
+				SelfLink: "https://hnrss.org/newest?description=0",
+			}
+
+			if tc.outputParamsFunc != nil {
+				tc.outputParamsFunc(outputParams)
+			}
+
+			feed, err := hnrss.NewRSS(results, outputParams)
+
+			require.NoError(t, err)
+			require.Len(t, feed.Items, len(results.Hits))
+			tc.want(t, feed.Items[0].Description)
+		})
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -96,13 +96,31 @@ func Generate(c *gin.Context, sp *SearchParams, op *OutputParams) {
 
 	switch op.Format {
 	case "rss":
-		rss := NewRSS(results, op)
+		rss, err := NewRSS(results, op)
+		if err != nil {
+			c.Error(err)
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+
 		c.XML(http.StatusOK, rss)
 	case "atom":
-		atom := NewAtom(results, op)
+		atom, err := NewAtom(results, op)
+		if err != nil {
+			c.Error(err)
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+
 		c.XML(http.StatusOK, atom)
 	case "jsonfeed":
-		jsonfeed := NewJSONFeed(results, op)
+		jsonfeed, err := NewJSONFeed(results, op)
+		if err != nil {
+			c.Error(err)
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+
 		c.JSON(http.StatusOK, jsonfeed)
 	}
 }


### PR DESCRIPTION
## Problem

New logic was added within #63 that meant that the description flag now works as documented, however we don't have any unit tests to cover this new functionality.

## Solution

- Add a new unit test `TestNewRSSOutputParamsDescription`
- Fix a few linting issues in the project
- Add a Github action to run the unit tests on each push to the project
- Added a few badges to the README for visibility

## Notes

- Not sure if Github action will work immediately as a maintainer may need to enable it
- The unit tests follow the table driven test pattern, see [Prefer table driven tests](https://dave.cheney.net/2019/05/07/prefer-table-driven-tests)