### PR TITLE
Fix Linting Errors

### DIFF
--- a/algolia.go
+++ b/algolia.go
@@ -85,7 +85,7 @@ func buildTemplateEngine(name string) *template.Template {
 	return t.Funcs(fm)
 }
 
-func (hit AlgoliaSearchHit) GetDescription() string {
+func (hit AlgoliaSearchHit) GetDescription() (string, error) {
 	var (
 		b bytes.Buffer
 		t = buildTemplateEngine("default")
@@ -112,8 +112,12 @@ func (hit AlgoliaSearchHit) GetDescription() string {
 `))
 	}
 
-	t.Execute(&b, hit)
-	return b.String()
+	err := t.Execute(&b, hit)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate description template: %w", err)
+	}
+
+	return b.String(), nil
 }
 
 func (hit AlgoliaSearchHit) GetCreatedAt() time.Time {

--- a/atom.go
+++ b/atom.go
@@ -32,7 +32,7 @@ type AtomLink struct {
 	Type         string `xml:"type,attr,omitempty"`
 }
 
-func NewAtom(results *AlgoliaSearchResponse, op *OutputParams) *Atom {
+func NewAtom(results *AlgoliaSearchResponse, op *OutputParams) (*Atom, error) {
 	atom := Atom{
 		NS:      NSAtom,
 		ID:      op.SelfLink,
@@ -56,11 +56,19 @@ func NewAtom(results *AlgoliaSearchResponse, op *OutputParams) *Atom {
 		}
 
 		if op.Description != descriptionDisabledFlag {
-			entry.Content = &AtomContent{"html", hit.GetDescription()}
+			desc, err := hit.GetDescription()
+			if err != nil {
+				return nil, err
+			}
+
+			entry.Content = &AtomContent{
+				Type:  "html",
+				Value: desc,
+			}
 		}
 
 		atom.Entries = append(atom.Entries, entry)
 	}
 
-	return &atom
+	return &atom, nil
 }

--- a/bestcomments.go
+++ b/bestcomments.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"astuart.co/goq"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"astuart.co/goq"
+	"github.com/gin-gonic/gin"
 )
 
 func BestComments(c *gin.Context) {
@@ -37,7 +38,7 @@ func BestComments(c *gin.Context) {
 	sp.Filters = strings.Join(oids, " OR ")
 	sp.Count = strconv.Itoa(len(oids))
 
-	op.Title = fmt.Sprintf("Hacker News: Best Comments")
+	op.Title = "Hacker News: Best Comments"
 	op.Link = "https://news.ycombinator.com/bestcomments"
 
 	Generate(c, &sp, &op)

--- a/favorites.go
+++ b/favorites.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"astuart.co/goq"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"astuart.co/goq"
+	"github.com/gin-gonic/gin"
 )
 
 const (

--- a/handlers.go
+++ b/handlers.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 func Newest(c *gin.Context) {
@@ -221,7 +222,7 @@ func Item(c *gin.Context) {
 	ParseRequest(c, &sp, &op)
 
 	sp.Tags = "comment,story_" + sp.ID
-	if (sp.Author != "") {
+	if sp.Author != "" {
 		sp.Tags = fmt.Sprintf("%s,author_%s", sp.Tags, sp.Author)
 	}
 	sp.SearchAttributes = "default"

--- a/jsonfeed.go
+++ b/jsonfeed.go
@@ -28,7 +28,7 @@ type JSONFeedItemAuthor struct {
 	URL  string `json:"url"`
 }
 
-func NewJSONFeed(results *AlgoliaSearchResponse, op *OutputParams) *JSONFeed {
+func NewJSONFeed(results *AlgoliaSearchResponse, op *OutputParams) (*JSONFeed, error) {
 	j := JSONFeed{
 		Version:     "https://jsonfeed.org/version/1",
 		Title:       op.Title,
@@ -49,10 +49,15 @@ func NewJSONFeed(results *AlgoliaSearchResponse, op *OutputParams) *JSONFeed {
 		}
 
 		if op.Description != descriptionDisabledFlag {
-			item.ContentHTML = hit.GetDescription()
+			desc, err := hit.GetDescription()
+			if err != nil {
+				return nil, err
+			}
+
+			item.ContentHTML = desc
 		}
 
 		j.Items = append(j.Items, item)
 	}
-	return &j
+	return &j, nil
 }

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 		}
 	}()
 
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt)
 	<-quit
 	log.Println("Shutting down server...")

--- a/rss.go
+++ b/rss.go
@@ -33,7 +33,7 @@ type RSSItem struct {
 	Permalink   RSSPermalink `xml:"guid"`
 }
 
-func NewRSS(results *AlgoliaSearchResponse, op *OutputParams) *RSS {
+func NewRSS(results *AlgoliaSearchResponse, op *OutputParams) (*RSS, error) {
 	rss := RSS{
 		Version:       "2.0",
 		NSAtom:        NSAtom,
@@ -58,11 +58,18 @@ func NewRSS(results *AlgoliaSearchResponse, op *OutputParams) *RSS {
 		}
 
 		if op.Description != descriptionDisabledFlag {
-			item.Description = &CDATA{hit.GetDescription()}
+			desc, err := hit.GetDescription()
+			if err != nil {
+				return nil, err
+			}
+
+			item.Description = &CDATA{
+				Value: desc,
+			}
 		}
 
 		rss.Items = append(rss.Items, item)
 	}
 
-	return &rss
+	return &rss, nil
 }

--- a/special.go
+++ b/special.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"astuart.co/goq"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"astuart.co/goq"
+	"github.com/gin-gonic/gin"
 )
 
 func Special(url, title string) gin.HandlerFunc {

--- a/utils.go
+++ b/utils.go
@@ -96,13 +96,28 @@ func Generate(c *gin.Context, sp *SearchParams, op *OutputParams) {
 
 	switch op.Format {
 	case "rss":
-		rss := NewRSS(results, op)
+		rss, err := NewRSS(results, op)
+		if err != nil {
+			c.Error(err)
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
 		c.XML(http.StatusOK, rss)
 	case "atom":
-		atom := NewAtom(results, op)
+		atom, err := NewAtom(results, op)
+		if err != nil {
+			c.Error(err)
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
 		c.XML(http.StatusOK, atom)
 	case "jsonfeed":
-		jsonfeed := NewJSONFeed(results, op)
+		jsonfeed, err := NewJSONFeed(results, op)
+		if err != nil {
+			c.Error(err)
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
 		c.JSON(http.StatusOK, jsonfeed)
 	}
 }

--- a/whoishiring.go
+++ b/whoishiring.go
@@ -3,10 +3,11 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 func HiringCommon(c *gin.Context, query string) {


### PR DESCRIPTION
Split off PR from #65.

## Problem

Number of linting errors were highlighted by running [golangci-lin](https://golangci-lint.run/).

## Solution

Fix them:

- Ensure errors are not ignored
- Remove use of `fmt.Sprintf` as was a normal string
- Fix import order within files
- Set buffer size to `1` for `os.Interrupt` signal