### PR TITLE
✨ Support highlights endpoint

### DIFF
--- a/highlights.go
+++ b/highlights.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"astuart.co/goq"
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+func Highlights(c *gin.Context) {
+	var sp SearchParams
+	var op OutputParams
+	ParseRequest(c, &sp, &op)
+
+	resp, err := algoliaClient.Get("https://news.ycombinator.com/highlights")
+	if err != nil {
+		c.Error(err)
+		c.String(http.StatusBadGateway, err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	var parsed ItemList
+	err = goq.NewDecoder(resp.Body).Decode(&parsed)
+	if err != nil {
+		c.Error(err)
+		c.String(http.StatusBadGateway, err.Error())
+		return
+	}
+
+	var oids []string
+	for _, id := range parsed.Thing {
+		oids = append(oids, fmt.Sprintf("objectID:\"%s\"", id))
+	}
+	sp.Filters = strings.Join(oids, " OR ")
+	sp.Count = strconv.Itoa(len(oids))
+
+	op.Title = fmt.Sprintf("Hacker News: Highlighted (curated) Comments")
+	op.Link = "https://news.ycombinator.com/highlights"
+
+	Generate(c, &sp, &op)
+}

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ func main() {
 	registerEndpoint(r, "/replies", Replies)
 	registerEndpoint(r, "/item", Item)
 	registerEndpoint(r, "/favorites", Favorites)
+	registerEndpoint(r, "/highlights", Highlights)
 	registerEndpoint(r, "/bestcomments", BestComments)
 	registerEndpoint(r, "/classic", Special("https://news.ycombinator.com/classic", "Hacker News: Classic"))
 	registerEndpoint(r, "/best", Special("https://news.ycombinator.com/best", "Hacker News: Best"))


### PR DESCRIPTION
It introduces a new /highlights endpoint allowing to following this manually curated list of interesting comments. This endpoint is not documented on HN but was recently discussed on https://news.ycombinator.com/item?id=35809302

This fixes #83