### PR TITLE
Make millis optional when parsing created_at

### DIFF
--- a/algolia.go
+++ b/algolia.go
@@ -117,7 +117,7 @@ func (hit AlgoliaSearchHit) GetDescription() string {
 }
 
 func (hit AlgoliaSearchHit) GetCreatedAt() time.Time {
-	if rv, err := time.Parse("2006-01-02T15:04:05.000Z", hit.CreatedAt); err == nil {
+	if rv, err := time.Parse("2006-01-02T15:04:05Z", hit.CreatedAt); err == nil {
 		return rv
 	} else {
 		return UTCNow()


### PR DESCRIPTION
`created_at` parsing appears to failing, an RSS feed that I subscribe to is endlessly re-posting the same content. I believe this is to do the [error handling](https://github.com/hnrss/hnrss/blob/9e41d6c/algolia.go#L123) assigning the current timestamp when `created_at` fails to parse. 

The code appears to be parsing with a time format that requires millis, but that's not what I see from the search results. For example, the first hit ("Ask HN: What's the big deal with Go (Golang)?") from https://hn.algolia.com/api/v1/search_by_date?query=golang&tags=story currently has `"created_at": "2023-10-11T21:57:57Z"`. However, that same result (and all others) at https://hnrss.org/newest?q=golang has `<pubDate>Thu, 12 Oct 2023 04:45:33 +0000</pubDate>`

The proposed parsing format seems to allow for the presence or absence of millis, making it slightly more resilient.