### PR TITLE
Update IP Binding

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	bindAddr    = flag.String("bind", "127.0.0.1:9000", "HOST:PORT")
+	bindAddr    = flag.String("bind", "0.0.0.0:9000", "HOST:PORT")
 	buildString string
 )
 


### PR DESCRIPTION
When working on an [HNRSS Docker image](https://github.com/cascadingstyletrees/hnrss-docker), I noticed the IP binding only serves for the local machine.

This change provides better compatibility with Containers, and serving locally.